### PR TITLE
feat: add PD statistics endpoint

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -2,6 +2,31 @@ import { z } from 'zod';
 
 const API_VERSION = 'v2';
 
+const advancedDateTimeFilterSchema = z.object({
+	$eq: z.string().optional(),
+	$neq: z.string().optional(),
+	$exists: z.boolean().optional(),
+	$gt: z.string().optional(),
+	$gte: z.string().optional(),
+	$lt: z.string().optional(),
+	$lte: z.string().optional(),
+	$in: z.array(z.string()).optional(),
+});
+type AdvancedDateTimeFilter = z.infer<typeof advancedDateTimeFilterSchema>;
+
+const advancedStringFilterSchema = z.object({
+	$like: z.string().optional(),
+});
+type AdvancedStringFilter = z.infer<typeof advancedStringFilterSchema>;
+
+const basicStringFilterSchema = z.object({
+	$eq: z.string().optional(),
+	$neq: z.string().optional(),
+	$exists: z.boolean().optional(),
+	$in: z.array(z.string()).optional(),
+});
+type BasicStringFilter = z.infer<typeof basicStringFilterSchema>;
+
 const problemDetailsSchema = z.object({
 	type: z.string(),
 	title: z.string(),
@@ -79,6 +104,9 @@ interface Endpoint<URLParams extends object | undefined = undefined> {
 
 export {
 	API_VERSION,
+	advancedDateTimeFilterSchema,
+	advancedStringFilterSchema,
+	basicStringFilterSchema,
 	problemDetailsSchema,
 	querySortOrderSchema,
 	queryPageSchema,
@@ -86,4 +114,13 @@ export {
 	getQueryResponseBodySchema,
 	getQueryRequestBodySchema,
 };
-export type { ProblemDetails, QuerySortOrder, QueryPage, Endpoint, QueryResponseBody };
+export type {
+	AdvancedDateTimeFilter,
+	AdvancedStringFilter,
+	BasicStringFilter,
+	ProblemDetails,
+	QuerySortOrder,
+	QueryPage,
+	Endpoint,
+	QueryResponseBody,
+};

--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -7,11 +7,8 @@ import {
 	type Endpoint,
 } from './common';
 
-const processInstanceState = z.enum(['ACTIVE', 'COMPLETED', 'TERMINATED']);
-type ProcessInstanceState = z.infer<typeof processInstanceState>;
-
-const statisticName = z.enum(['flownode-instances']);
-type StatisticName = z.infer<typeof statisticName>;
+type ProcessInstanceState = 'ACTIVE' | 'COMPLETED' | 'TERMINATED';
+type StatisticName = 'flownode-instances';
 
 const processDefinitionSchema = z.object({
 	processDefinitionKey: z.number(),
@@ -47,7 +44,7 @@ const getProcessDefinitionStatisticsRequestBodySchema = z.object({
 	filter: z.object({
 		startDate: advancedDateTimeFilterSchema.optional(),
 		endDate: advancedDateTimeFilterSchema.optional(),
-		state: processInstanceState.optional(),
+		state: z.enum(['ACTIVE', 'COMPLETED', 'TERMINATED']).optional(),
 		hasIncident: z.boolean().optional(),
 		tenantId: advancedDateTimeFilterSchema.optional(),
 		variables: z.array(
@@ -69,8 +66,7 @@ const getProcessDefinitionStatisticsResponseBodySchema = getQueryResponseBodySch
 );
 type GetProcessDefinitionStatisticsResponseBody = z.infer<typeof getProcessDefinitionStatisticsResponseBodySchema>;
 
-type GetProcessDefinitionStatisticsParams = {
-	processDefinitionKey: string;
+type GetProcessDefinitionStatisticsParams = Pick<ProcessDefinition, 'processDefinitionKey'> & {
 	statisticName: StatisticName;
 };
 
@@ -99,11 +95,8 @@ export {
 	getProcessDefinitionStatisticsRequestBodySchema,
 	getProcessDefinitionStatisticsResponseBodySchema,
 	processDefinitionSchema,
-	processInstanceState,
-	statisticName,
 };
 export type {
-	GetProcessDefinitionStatisticsParams,
 	GetProcessDefinitionStatisticsRequestBody,
 	GetProcessDefinitionStatisticsResponseBody,
 	ProcessDefinition,

--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod';
-import { API_VERSION, type Endpoint } from './common';
+import {
+	advancedDateTimeFilterSchema,
+	API_VERSION,
+	basicStringFilterSchema,
+	getQueryResponseBodySchema,
+	type Endpoint,
+} from './common';
+
+const processInstanceState = z.enum(['ACTIVE', 'COMPLETED', 'TERMINATED']);
+type ProcessInstanceState = z.infer<typeof processInstanceState>;
+
+const statisticName = z.enum(['flownode-instances']);
+type StatisticName = z.infer<typeof statisticName>;
 
 const processDefinitionSchema = z.object({
 	processDefinitionKey: z.number(),
@@ -21,6 +33,56 @@ const getProcessDefinition: Endpoint<Pick<ProcessDefinition, 'processDefinitionK
 	},
 };
 
+const processDefinitionStatisticsBodySchema = z.array(
+	z.object({
+		flowNodeId: z.string(),
+		active: z.number(),
+		canceled: z.number(),
+		incidents: z.number(),
+		completed: z.number(),
+	}),
+);
+
+const getProcessDefinitionStatisticsRequestBodySchema = z.object({
+	filter: z.object({
+		startDate: advancedDateTimeFilterSchema.optional(),
+		endDate: advancedDateTimeFilterSchema.optional(),
+		state: processInstanceState.optional(),
+		hasIncident: z.boolean().optional(),
+		tenantId: advancedDateTimeFilterSchema.optional(),
+		variables: z.array(
+			z.object({
+				name: z.string(),
+				value: z.string(),
+			}),
+		),
+		processInstanceKey: basicStringFilterSchema.optional(),
+		parentProcessInstanceKey: basicStringFilterSchema.optional(),
+		parentFlowNodeInstanceKey: basicStringFilterSchema.optional(),
+	}),
+});
+
+type GetProcessDefinitionStatisticsRequestBody = z.infer<typeof getProcessDefinitionStatisticsRequestBodySchema>;
+
+const getProcessDefinitionStatisticsResponseBodySchema = getQueryResponseBodySchema(
+	processDefinitionStatisticsBodySchema,
+);
+type GetProcessDefinitionStatisticsResponseBody = z.infer<typeof getProcessDefinitionStatisticsResponseBodySchema>;
+
+type GetProcessDefinitionStatisticsParams = {
+	processDefinitionKey: string;
+	statisticName: StatisticName;
+};
+
+const getProcessDefinitionStatistics: Endpoint<GetProcessDefinitionStatisticsParams> = {
+	method: 'POST',
+	getUrl(params) {
+		const { processDefinitionKey, statisticName = 'flownode-instances' } = params;
+
+		return `/${API_VERSION}/process-definitions/${processDefinitionKey}/statistics/${statisticName}`;
+	},
+};
+
 const getProcessDefinitionXml: Endpoint<Pick<ProcessDefinition, 'processDefinitionKey'>> = {
 	method: 'GET',
 	getUrl(params) {
@@ -30,7 +92,21 @@ const getProcessDefinitionXml: Endpoint<Pick<ProcessDefinition, 'processDefiniti
 	},
 };
 
-const endpoints = { getProcessDefinition, getProcessDefinitionXml } as const;
+const endpoints = { getProcessDefinition, getProcessDefinitionStatistics, getProcessDefinitionXml } as const;
 
-export { endpoints, processDefinitionSchema };
-export type { ProcessDefinition };
+export {
+	endpoints,
+	getProcessDefinitionStatisticsRequestBodySchema,
+	getProcessDefinitionStatisticsResponseBodySchema,
+	processDefinitionSchema,
+	processInstanceState,
+	statisticName,
+};
+export type {
+	GetProcessDefinitionStatisticsParams,
+	GetProcessDefinitionStatisticsRequestBody,
+	GetProcessDefinitionStatisticsResponseBody,
+	ProcessDefinition,
+	ProcessInstanceState,
+	StatisticName,
+};


### PR DESCRIPTION
# Description
This PR adds a new POST endpoint for process definition statistics (part of [Operate API V2 migration](https://github.com/camunda/camunda/issues/27250)).
The backend endpoint was introduced [in this PR](https://github.com/camunda/camunda/pull/29234/files).

# Related issue
https://github.com/camunda/camunda/issues/29378