### PR TITLE
feat: add decision definition xml endpoint

### DIFF
--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -135,6 +135,7 @@ export {
 export type {
 	GetProcessDefinitionStatisticsRequestBody,
 	GetProcessDefinitionStatisticsResponseBody,
+	DecisionDefinition,
 	GetDecisionDefinitionXmlResponseBody,
 	ProcessDefinition,
 	ProcessInstanceState,

--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -92,17 +92,50 @@ const getProcessDefinitionXml: Endpoint<Pick<ProcessDefinition, 'processDefiniti
 	},
 };
 
-const endpoints = { getProcessDefinition, getProcessDefinitionStatistics, getProcessDefinitionXml } as const;
+const decisionDefinitionSchema = z.object({
+	decisionDefinitionId: z.string(),
+	name: z.string(),
+	version: z.number(),
+	decisionRequirementsId: z.string(),
+	tenantId: z.string(),
+	decisionDefinitionKey: z.string(),
+	decisionRequirementsKey: z.string(),
+});
+type DecisionDefinition = z.infer<typeof decisionDefinitionSchema>;
+
+const getDecisionDefinitionXmlResponseBodySchema = z.string();
+type GetDecisionDefinitionXmlResponseBody = z.infer<typeof getDecisionDefinitionXmlResponseBodySchema>;
+
+type GetDecisionDefinitionXmlParams = Pick<DecisionDefinition, 'decisionDefinitionKey'>;
+
+const getDecisionDefinitionXml: Endpoint<GetDecisionDefinitionXmlParams> = {
+	method: 'GET',
+	getUrl(params) {
+		const { decisionDefinitionKey } = params;
+
+		return `/${API_VERSION}/decision-definitions/${decisionDefinitionKey}/xml`;
+	},
+};
+
+const endpoints = {
+	getProcessDefinition,
+	getProcessDefinitionStatistics,
+	getProcessDefinitionXml,
+	getDecisionDefinitionXml,
+} as const;
 
 export {
 	endpoints,
 	getProcessDefinitionStatisticsRequestBodySchema,
 	getProcessDefinitionStatisticsResponseBodySchema,
 	processDefinitionSchema,
+	decisionDefinitionSchema,
+	getDecisionDefinitionXmlResponseBodySchema,
 };
 export type {
 	GetProcessDefinitionStatisticsRequestBody,
 	GetProcessDefinitionStatisticsResponseBody,
+	GetDecisionDefinitionXmlResponseBody,
 	ProcessDefinition,
 	ProcessInstanceState,
 	StatisticName,


### PR DESCRIPTION
This PR adds a new schema for decision definition and the [decision definition xml endoint](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/get-decision-definition-xml/).