### PR TITLE
fix: use items in PD statistics response

### DIFF
--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -67,7 +67,7 @@ const getProcessDefinitionStatisticsRequestBodySchema = z.object({
 
 type GetProcessDefinitionStatisticsRequestBody = z.infer<typeof getProcessDefinitionStatisticsRequestBodySchema>;
 
-const getProcessDefinitionStatisticsResponseBodySchema = z.array(processDefinitionStatisticSchema);
+const getProcessDefinitionStatisticsResponseBodySchema = z.object({ items: z.array(processDefinitionStatisticSchema) });
 type GetProcessDefinitionStatisticsResponseBody = z.infer<typeof getProcessDefinitionStatisticsResponseBodySchema>;
 
 type GetProcessDefinitionStatisticsParams = Pick<ProcessDefinition, 'processDefinitionId'> & {


### PR DESCRIPTION
This PR is adding an `items` field in the response instead of just having a list. [slack message](https://camunda.slack.com/archives/C088A1LL5CZ/p1742973253917179?thread_ts=1742954581.198699&cid=C088A1LL5CZ) for context