### PR TITLE
feat: add flownode instance statistics endpoint

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -70,6 +70,14 @@ function getQueryResponseBodySchema<ItemSchema extends z.ZodTypeAny>(
 	});
 }
 
+function getItemsArrayResponseBodySchema<ItemSchema extends z.ZodTypeAny>(
+	itemSchema: ItemSchema,
+): z.ZodType<{ items: z.infer<ItemSchema>[] }> {
+	return z.object({
+		items: z.array(itemSchema),
+	});
+}
+
 function getQueryRequestSortSchema<Fields extends [string, ...string[]]>(fields: Fields) {
 	return z.array(
 		z.object({
@@ -111,6 +119,7 @@ export {
 	querySortOrderSchema,
 	queryPageSchema,
 	queryResponsePageSchema,
+	getItemsArrayResponseBodySchema,
 	getQueryResponseBodySchema,
 	getQueryRequestBodySchema,
 };

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -70,7 +70,7 @@ function getQueryResponseBodySchema<ItemSchema extends z.ZodTypeAny>(
 	});
 }
 
-function getItemsArrayResponseBodySchema<ItemSchema extends z.ZodTypeAny>(
+function getCollectionResponseBodySchema<ItemSchema extends z.ZodTypeAny>(
 	itemSchema: ItemSchema,
 ): z.ZodType<{ items: z.infer<ItemSchema>[] }> {
 	return z.object({
@@ -119,7 +119,7 @@ export {
 	querySortOrderSchema,
 	queryPageSchema,
 	queryResponsePageSchema,
-	getItemsArrayResponseBodySchema,
+	getCollectionResponseBodySchema,
 	getQueryResponseBodySchema,
 	getQueryRequestBodySchema,
 };

--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import { advancedDateTimeFilterSchema, API_VERSION, basicStringFilterSchema, type Endpoint } from './common';
+import {
+	advancedDateTimeFilterSchema,
+	API_VERSION,
+	basicStringFilterSchema,
+	getItemsArrayResponseBodySchema,
+	type Endpoint,
+} from './common';
 
 const processInstanceState = z.enum(['ACTIVE', 'COMPLETED', 'TERMINATED']);
 type ProcessInstanceState = z.infer<typeof processInstanceState>;
@@ -15,6 +21,11 @@ const processDefinitionSchema = z.object({
 	formKey: z.number(),
 });
 type ProcessDefinition = z.infer<typeof processDefinitionSchema>;
+
+const processInstanceSchema = z.object({
+	processInstanceKey: z.string(),
+});
+type ProcessInstance = z.infer<typeof processInstanceSchema>;
 
 const getProcessDefinition: Endpoint<Pick<ProcessDefinition, 'processDefinitionKey'>> = {
 	method: 'GET',
@@ -67,7 +78,9 @@ const getProcessDefinitionStatisticsRequestBodySchema = z.object({
 
 type GetProcessDefinitionStatisticsRequestBody = z.infer<typeof getProcessDefinitionStatisticsRequestBodySchema>;
 
-const getProcessDefinitionStatisticsResponseBodySchema = z.object({ items: z.array(processDefinitionStatisticSchema) });
+const getProcessDefinitionStatisticsResponseBodySchema = getItemsArrayResponseBodySchema(
+	processDefinitionStatisticSchema,
+);
 type GetProcessDefinitionStatisticsResponseBody = z.infer<typeof getProcessDefinitionStatisticsResponseBodySchema>;
 
 type GetProcessDefinitionStatisticsParams = Pick<ProcessDefinition, 'processDefinitionId'> & {
@@ -108,6 +121,24 @@ type GetDecisionDefinitionXmlResponseBody = z.infer<typeof getDecisionDefinition
 
 type GetDecisionDefinitionXmlParams = Pick<DecisionDefinition, 'decisionDefinitionKey'>;
 
+const getProcessInstanceStatistics: Endpoint<GetProcessInstanceStatisticsParams> = {
+	method: 'GET',
+	getUrl(params) {
+		const { processInstanceKey, statisticName = 'flownode-instances' } = params;
+
+		return `/${API_VERSION}/process-instances/${processInstanceKey}/statistics/${statisticName}`;
+	},
+};
+
+const getProcessInstanceStatisticsResponseBodySchema = getItemsArrayResponseBodySchema(
+	processDefinitionStatisticSchema,
+);
+type GetProcessInstanceStatisticsResponseBody = z.infer<typeof getProcessInstanceStatisticsResponseBodySchema>;
+
+type GetProcessInstanceStatisticsParams = Pick<ProcessInstance, 'processInstanceKey'> & {
+	statisticName: StatisticName;
+};
+
 const getDecisionDefinitionXml: Endpoint<GetDecisionDefinitionXmlParams> = {
 	method: 'GET',
 	getUrl(params) {
@@ -118,27 +149,30 @@ const getDecisionDefinitionXml: Endpoint<GetDecisionDefinitionXmlParams> = {
 };
 
 const endpoints = {
+	getDecisionDefinitionXml,
 	getProcessDefinition,
 	getProcessDefinitionStatistics,
 	getProcessDefinitionXml,
-	getDecisionDefinitionXml,
+	getProcessInstanceStatistics,
 } as const;
 
 export {
 	endpoints,
-	getProcessDefinitionStatisticsRequestBodySchema,
-	getProcessDefinitionStatisticsResponseBodySchema,
-	processDefinitionSchema,
 	decisionDefinitionSchema,
 	getDecisionDefinitionXmlResponseBodySchema,
+	getProcessDefinitionStatisticsRequestBodySchema,
+	getProcessDefinitionStatisticsResponseBodySchema,
+	getProcessInstanceStatisticsResponseBodySchema,
+	processDefinitionSchema,
 };
 export type {
-	GetProcessDefinitionStatisticsRequestBody,
-	GetProcessDefinitionStatisticsResponseBody,
 	DecisionDefinition,
 	GetDecisionDefinitionXmlResponseBody,
+	GetProcessDefinitionStatisticsRequestBody,
+	GetProcessDefinitionStatisticsResponseBody,
+	GetProcessInstanceStatisticsResponseBody,
 	ProcessDefinition,
+	ProcessDefinitionStatistic,
 	ProcessInstanceState,
 	StatisticName,
-	ProcessDefinitionStatistic,
 };

--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -3,7 +3,7 @@ import {
 	advancedDateTimeFilterSchema,
 	API_VERSION,
 	basicStringFilterSchema,
-	getItemsArrayResponseBodySchema,
+	getCollectionResponseBodySchema,
 	type Endpoint,
 } from './common';
 
@@ -78,7 +78,7 @@ const getProcessDefinitionStatisticsRequestBodySchema = z.object({
 
 type GetProcessDefinitionStatisticsRequestBody = z.infer<typeof getProcessDefinitionStatisticsRequestBodySchema>;
 
-const getProcessDefinitionStatisticsResponseBodySchema = getItemsArrayResponseBodySchema(
+const getProcessDefinitionStatisticsResponseBodySchema = getCollectionResponseBodySchema(
 	processDefinitionStatisticSchema,
 );
 type GetProcessDefinitionStatisticsResponseBody = z.infer<typeof getProcessDefinitionStatisticsResponseBodySchema>;
@@ -130,7 +130,7 @@ const getProcessInstanceStatistics: Endpoint<GetProcessInstanceStatisticsParams>
 	},
 };
 
-const getProcessInstanceStatisticsResponseBodySchema = getItemsArrayResponseBodySchema(
+const getProcessInstanceStatisticsResponseBodySchema = getCollectionResponseBodySchema(
 	processDefinitionStatisticSchema,
 );
 type GetProcessInstanceStatisticsResponseBody = z.infer<typeof getProcessInstanceStatisticsResponseBodySchema>;


### PR DESCRIPTION
This PR is adding a [v2 endpoint for flownode instances statistics](https://github.com/camunda/camunda/issues/30260).
The request/response structure is described in https://github.com/camunda/camunda/issues/21719