### PR TITLE
feat: query variables support pagination

### DIFF
--- a/lib/process-management.ts
+++ b/lib/process-management.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 import {
 	advancedStringFilterSchema,
 	API_VERSION,
-	getCollectionResponseBodySchema,
 	getQueryRequestBodySchema,
+	getQueryResponseBodySchema,
 	type Endpoint,
 } from './common';
 import { processInstanceSchema } from './operate';
@@ -48,7 +48,7 @@ const queryVariablesRequestBodySchema = getQueryRequestBodySchema({
 });
 type QueryVariablesRequestBody = z.infer<typeof queryVariablesRequestBodySchema>;
 
-const queryVariablesResponseBodySchema = getCollectionResponseBodySchema(variableSchema);
+const queryVariablesResponseBodySchema = getQueryResponseBodySchema(variableSchema);
 type QueryVariablesResponseBody = z.infer<typeof queryVariablesResponseBodySchema>;
 
 const queryVariables: Endpoint = {


### PR DESCRIPTION
Currently the variables query endpoint only returns `{items: ...}` but the [API docs](https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/specifications/search-variables/) suggests that it returns a paginated response (which is consistent with the parameters we send). This PR is changing the response to return `{items: ..., page: ...}`