### PR TITLE
feat: add sorting and pagination to jobs request body schema

### DIFF
--- a/lib/operate.ts
+++ b/lib/operate.ts
@@ -276,7 +276,30 @@ const jobStateFilter = getEnumFilterSchema(jobState);
 const jobKindFilter = getEnumFilterSchema(jobKind);
 const listenerEventTypeFilter = getEnumFilterSchema(listenerEventType);
 
-const getJobsRequestBodySchema = z.object({
+const getJobsRequestBodySchema = getQueryRequestBodySchema({
+	sortFields: [
+		"jobKey",
+		"type",
+		"worker",
+		"state",
+		"kind",
+		"listenerEventType",
+		"retries",
+		"isDenied",
+		"deniedReason",
+		"hasFailedWithRetriesLeft",
+		"errorCode",
+		"errorMessage",
+		"customHeaders",
+		"deadline",
+		"endTime",
+		"processDefinitionId",
+		"processDefinitionKey",
+		"processInstanceKey",
+		"elementId",
+		"elementInstanceKey",
+		"tenantId",
+	],
 	filter: z.object({
 		jobKey: basicStringFilterSchema.optional(),
 		type: advancedStringFilterSchema.optional(),


### PR DESCRIPTION
According to https://github.com/camunda/camunda/issues/31897 the jobs search endpoint should support pagination and sorting on all filtering and response fields.

This PR uses the `getQueryRequestBodySchema` method to ensure the `sort` and `page` fields are added to the request schema for the getJobs endpoint.

The response schema already uses the `getQueryResponseBodySchema` function.