### PR TITLE
feat: update pagination cursors

### DIFF
--- a/lib/common.ts
+++ b/lib/common.ts
@@ -67,16 +67,16 @@ const queryPageSchema = z
 	.object({
 		from: z.number().int(),
 		limit: z.number().int(),
-		searchBefore: z.tuple([z.number(), z.number()]),
-		searchAfter: z.tuple([z.number(), z.number()]),
+		searchBefore: z.string().optional(),
+		searchAfter: z.string().optional(),
 	})
 	.partial();
 type QueryPage = z.infer<typeof queryPageSchema>;
 
 const queryResponsePageSchema = z.object({
 	totalItems: z.number(),
-	firstSortValues: z.tuple([z.number(), z.number()]),
-	lastSortValues: z.tuple([z.number(), z.number()]),
+	searchBeforeCursor: z.string().optional(),
+	searchAfterCursor: z.string().optional(),
 });
 type QueryResponsePage = z.infer<typeof queryResponsePageSchema>;
 


### PR DESCRIPTION
We've made some improvements on the BE on the way our pagination is done. We no longer send lists in our `searchBefore` and `searchAfter` page parameters. Instead we send a [single cursor](https://github.com/camunda/camunda/pull/33026).
The zod page types need to be updated with the correct new name and type.

Issue : https://github.com/camunda/camunda/issues/29359