### PR TITLE
fix: rename process instance sequence flows response body

### DIFF
--- a/lib/8.8/index.ts
+++ b/lib/8.8/index.ts
@@ -327,10 +327,7 @@ export {
 	type QueryBatchOperationItemsRequestBody,
 	type QueryBatchOperationItemsResponseBody,
 } from './batch-operation';
-export {
-	pinClockRequestBodySchema,
-	type PinClockRequestBody,
-} from './clock';
+export { pinClockRequestBodySchema, type PinClockRequestBody } from './clock';
 export {
 	partitionRoleSchema,
 	partitionHealthSchema,
@@ -540,7 +537,7 @@ export {
 	queryProcessInstanceIncidentsRequestBodySchema,
 	getProcessInstanceCallHierarchyResponseBodySchema,
 	getProcessInstanceStatisticsResponseBodySchema,
-	getProcessSequenceFlowsResponseBodySchema,
+	getProcessInstanceSequenceFlowsResponseBodySchema,
 	processInstanceStateSchema,
 	processInstanceSchema,
 	sequenceFlowSchema,
@@ -554,7 +551,7 @@ export {
 	type CallHierarchy,
 	type GetProcessInstanceCallHierarchyResponseBody,
 	type SequenceFlow,
-	type GetProcessSequenceFlowsResponseBody,
+	type GetProcessInstanceSequenceFlowsResponseBody,
 	type ProcessInstanceState,
 	type StatisticName,
 	type ProcessInstance,

--- a/lib/8.8/process-instance.ts
+++ b/lib/8.8/process-instance.ts
@@ -194,8 +194,8 @@ const sequenceFlowSchema = z.object({
 });
 type SequenceFlow = z.infer<typeof sequenceFlowSchema>;
 
-const getProcessSequenceFlowsResponseBodySchema = getCollectionResponseBodySchema(sequenceFlowSchema);
-type GetProcessSequenceFlowsResponseBody = z.infer<typeof getProcessSequenceFlowsResponseBodySchema>;
+const getProcessInstanceSequenceFlowsResponseBodySchema = getCollectionResponseBodySchema(sequenceFlowSchema);
+type GetProcessInstanceSequenceFlowsResponseBody = z.infer<typeof getProcessInstanceSequenceFlowsResponseBodySchema>;
 
 export {
 	createProcessInstance,
@@ -214,7 +214,7 @@ export {
 	queryProcessInstanceIncidentsRequestBodySchema,
 	getProcessInstanceCallHierarchyResponseBodySchema,
 	getProcessInstanceStatisticsResponseBodySchema,
-	getProcessSequenceFlowsResponseBodySchema,
+	getProcessInstanceSequenceFlowsResponseBodySchema,
 	processInstanceStateSchema,
 	processInstanceSchema,
 	sequenceFlowSchema,
@@ -230,7 +230,7 @@ export type {
 	CallHierarchy,
 	GetProcessInstanceCallHierarchyResponseBody,
 	SequenceFlow,
-	GetProcessSequenceFlowsResponseBody,
+	GetProcessInstanceSequenceFlowsResponseBody,
 	ProcessInstanceState,
 	StatisticName,
 	ProcessInstance,


### PR DESCRIPTION
While integrating 1.0.0 I discovered this naming inconsistency. This PR should fix it.